### PR TITLE
Add minimal Telegram support bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Python
+__pycache__/
+*.py[cod]
+
+# Environments
+venv/
+.env
+
+# Misc
+*.log

--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # telegram-support-bot
-Telegram bot for customer support with group admin chat
+
+Telegram bot for customer support with group admin chat.
+
+## Features
+
+- Receives messages from users and forwards them to a support group.
+- Operators reply in the group and the bot relays the answer back to the user.
+- No automated FAQ: only direct communication with human operators.
+- Runs via long polling and works well on microcomputers such as Raspberry Pi.
+
+## Installation
+
+```bash
+git clone https://github.com/yourusername/telegram-support-bot.git
+cd telegram-support-bot
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+1. Create a bot with [@BotFather](https://t.me/BotFather) and obtain the token.
+2. Create a support group and find its chat ID.
+3. Run the bot:
+
+```bash
+export TELEGRAM_BOT_TOKEN="YOUR_TOKEN"
+export ADMIN_CHAT_ID="GROUP_CHAT_ID"
+python bot.py
+```
+
+Any message sent to the bot will be forwarded to the admin chat. When an operator replies to the forwarded message in the admin chat, the bot sends that reply back to the original user.

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,43 @@
+import os
+from typing import Dict
+from telegram import Update
+from telegram.ext import Application, CommandHandler, MessageHandler, ContextTypes, filters
+
+FORWARD_MAP_KEY = "forward_map"
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text("Здравствуйте! Напишите ваш вопрос, и оператор скоро ответит.")
+
+async def handle_user_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    admin_chat_id = int(os.environ["ADMIN_CHAT_ID"])
+    forwarded = await update.message.forward(admin_chat_id)
+    forward_map: Dict[int, int] = context.bot_data.setdefault(FORWARD_MAP_KEY, {})
+    forward_map[forwarded.message_id] = update.effective_chat.id
+
+async def handle_admin_reply(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    admin_chat_id = int(os.environ["ADMIN_CHAT_ID"])
+    if update.effective_chat.id != admin_chat_id:
+        return
+    if not update.message.reply_to_message:
+        return
+    forward_map: Dict[int, int] = context.bot_data.get(FORWARD_MAP_KEY, {})
+    user_chat_id = forward_map.get(update.message.reply_to_message.message_id)
+    if user_chat_id:
+        await update.message.copy(chat_id=user_chat_id)
+
+async def main() -> None:
+    token = os.environ["TELEGRAM_BOT_TOKEN"]
+    application = Application.builder().token(token).build()
+
+    application.add_handler(CommandHandler("start", start))
+    application.add_handler(MessageHandler(filters.ChatType.PRIVATE, handle_user_message))
+    application.add_handler(MessageHandler(filters.ALL, handle_admin_reply))
+
+    await application.initialize()
+    await application.start()
+    await application.updater.start_polling()
+    await application.updater.idle()
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-telegram-bot>=20,<21


### PR DESCRIPTION
## Summary
- implement simple Telegram bot that forwards user messages to a support chat and relays operator replies
- add dependencies and installation instructions for running on microcomputers
- add gitignore for Python artifacts

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68b08673753c8320ada1ede6190d2399