### PR TITLE
Ensure ForwardService closes database on shutdown

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -107,29 +107,32 @@ def main() -> None:
     db_path = os.environ.get("DB_PATH", "support.db")
     forward_service = ForwardService(db_path)
 
-    allowed_ids = os.environ.get("ALLOWED_USER_IDS", "")
-    for part in allowed_ids.split(","):
-        part = part.strip()
-        if part:
-            forward_service.add_allowed_user(int(part))
+    try:
+        allowed_ids = os.environ.get("ALLOWED_USER_IDS", "")
+        for part in allowed_ids.split(","):
+            part = part.strip()
+            if part:
+                forward_service.add_allowed_user(int(part))
 
-    application = Application.builder().token(token).build()
+        application = Application.builder().token(token).build()
 
-    application.add_handler(CommandHandler("start", start))
-    application.add_handler(CommandHandler("cancel", cancel))
-    application.add_handler(
-        MessageHandler(filters.TEXT & filters.ChatType.PRIVATE, handle_user_message)
-    )
-    application.add_handler(
-        MessageHandler(~filters.TEXT & filters.ChatType.PRIVATE, handle_unsupported)
-    )
-    application.add_handler(
-        MessageHandler(filters.Chat(ADMIN_CHAT_IDS) & filters.REPLY, handle_admin_reply)
-    )
+        application.add_handler(CommandHandler("start", start))
+        application.add_handler(CommandHandler("cancel", cancel))
+        application.add_handler(
+            MessageHandler(filters.TEXT & filters.ChatType.PRIVATE, handle_user_message)
+        )
+        application.add_handler(
+            MessageHandler(~filters.TEXT & filters.ChatType.PRIVATE, handle_unsupported)
+        )
+        application.add_handler(
+            MessageHandler(filters.Chat(ADMIN_CHAT_IDS) & filters.REPLY, handle_admin_reply)
+        )
 
-    application.add_error_handler(error_handler)
+        application.add_error_handler(error_handler)
 
-    application.run_polling()
+        application.run_polling()
+    finally:
+        forward_service.close()
 
 
 if __name__ == "__main__":

--- a/services/forwarding.py
+++ b/services/forwarding.py
@@ -9,6 +9,17 @@ class ForwardService:
         self.conn = sqlite3.connect(db_path)
         self._init_db()
 
+    def close(self) -> None:
+        """Close the underlying database connection."""
+        self.conn.close()
+
+    # Context manager support -------------------------------------------------
+    def __enter__(self) -> "ForwardService":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - simple
+        self.close()
+
     def _init_db(self) -> None:
         cur = self.conn.cursor()
         cur.execute(

--- a/tests/test_forward_service.py
+++ b/tests/test_forward_service.py
@@ -1,5 +1,8 @@
 import os
+import sqlite3
 import sys
+
+import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
@@ -19,3 +22,10 @@ def test_access_control():
     service.add_allowed_user(2)
     assert service.is_allowed(1)
     assert not service.is_allowed(3)
+
+
+def test_close_prevents_further_operations():
+    service = ForwardService(":memory:")
+    service.close()
+    with pytest.raises(sqlite3.ProgrammingError):
+        service.record_forward(admin_id=1, forwarded_message_id=1, user_chat_id=1)


### PR DESCRIPTION
## Summary
- add `ForwardService.close()` with context manager support
- close database connection when bot shuts down
- test that operations fail after closing the service

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b08dd95dd88320953e35182fc6127b