### PR TITLE
Add allowed user management commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -100,6 +100,32 @@ async def handle_admin_reply(update: Update, context: ContextTypes.DEFAULT_TYPE)
         )
 
 
+async def allow(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not context.args:
+        await update.message.reply_text("Использование: /allow <user_id>")
+        return
+    try:
+        user_id = int(context.args[0])
+    except ValueError:
+        await update.message.reply_text("Некорректный user_id")
+        return
+    forward_service.add_allowed_user(user_id)
+    await update.message.reply_text(f"Пользователь {user_id} добавлен.")
+
+
+async def disallow(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not context.args:
+        await update.message.reply_text("Использование: /disallow <user_id>")
+        return
+    try:
+        user_id = int(context.args[0])
+    except ValueError:
+        await update.message.reply_text("Некорректный user_id")
+        return
+    forward_service.remove_allowed_user(user_id)
+    await update.message.reply_text(f"Пользователь {user_id} удалён.")
+
+
 async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
     logger.error("Exception while handling an update:", exc_info=context.error)
     if isinstance(update, Update) and update.effective_message:
@@ -129,6 +155,12 @@ def main() -> None:
 
         application.add_handler(CommandHandler("start", start))
         application.add_handler(CommandHandler("cancel", cancel))
+        application.add_handler(
+            CommandHandler("allow", allow, filters.Chat(ADMIN_CHAT_IDS))
+        )
+        application.add_handler(
+            CommandHandler("disallow", disallow, filters.Chat(ADMIN_CHAT_IDS))
+        )
         application.add_handler(
             MessageHandler(
                 (filters.GAME | filters.LOCATION) & filters.ChatType.PRIVATE,

--- a/services/forwarding.py
+++ b/services/forwarding.py
@@ -60,6 +60,16 @@ class ForwardService:
         self.conn.execute("INSERT OR IGNORE INTO allowed_users(user_id) VALUES (?)", (user_id,))
         self.conn.commit()
 
+    def remove_allowed_user(self, user_id: int) -> None:
+        """Remove a user from the allowed users list."""
+        self.conn.execute("DELETE FROM allowed_users WHERE user_id=?", (user_id,))
+        self.conn.commit()
+
+    def get_allowed_users(self) -> list[int]:
+        """Return a list of all allowed user IDs."""
+        cur = self.conn.execute("SELECT user_id FROM allowed_users")
+        return [row[0] for row in cur.fetchall()]
+
     def is_allowed(self, user_id: int) -> bool:
         cur_total = self.conn.execute("SELECT COUNT(*) FROM allowed_users")
         total = cur_total.fetchone()[0]

--- a/tests/test_forward_service.py
+++ b/tests/test_forward_service.py
@@ -24,8 +24,18 @@ def test_access_control():
     assert not service.is_allowed(3)
 
 
+def test_manage_allowed_users():
+    service = ForwardService(":memory:")
+    service.add_allowed_user(10)
+    service.add_allowed_user(11)
+    assert set(service.get_allowed_users()) == {10, 11}
+    service.remove_allowed_user(10)
+    assert service.get_allowed_users() == [11]
+
+
 def test_close_prevents_further_operations():
     service = ForwardService(":memory:")
     service.close()
     with pytest.raises(sqlite3.ProgrammingError):
         service.record_forward(admin_id=1, forwarded_message_id=1, user_chat_id=1)
+

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -80,3 +80,22 @@ def test_handle_admin_reply_uses_mapping(application):
     application.bot.copy_message.assert_awaited_once_with(
         chat_id=200, from_chat_id=1, message_id=20
     )
+
+
+def test_allow_and_disallow_commands(application):
+    bot.ADMIN_CHAT_IDS = [1]
+    bot.forward_service = ForwardService(":memory:")
+    # allow command
+    message = DummyMessage(1)
+    update = DummyUpdate(message, user_id=1, chat_id=1)
+    context = SimpleNamespace(args=["50"], bot=application.bot)
+    asyncio.run(bot.allow(update, context))
+    assert 50 in bot.forward_service.get_allowed_users()
+    message.reply_text.assert_awaited_once()
+    # disallow command
+    message2 = DummyMessage(2)
+    update2 = DummyUpdate(message2, user_id=1, chat_id=1)
+    context2 = SimpleNamespace(args=["50"], bot=application.bot)
+    asyncio.run(bot.disallow(update2, context2))
+    assert 50 not in bot.forward_service.get_allowed_users()
+    message2.reply_text.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Add methods to manage allowed users in the forwarding service
- Introduce /allow and /disallow admin commands to modify access list
- Cover new functionality with unit tests

## Testing
- `pytest tests/test_forward_service.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'telegram')*


------
https://chatgpt.com/codex/tasks/task_e_68b091392e648320b8192f8bdafe115f